### PR TITLE
Update PHPZabbix.php

### DIFF
--- a/src/PHPZabbix.php
+++ b/src/PHPZabbix.php
@@ -8,8 +8,6 @@ use phpzabbix\JSONRPC\Response;
 use phpzabbix\JSONRPC\RequestCallbackInterface;
 use phpzabbix\JSONRPC\ErrorException;
 
-use \GuzzleHttp\ClientInterface;
-
 class PHPZabbix implements RequestCallbackInterface
 {
     public $client;
@@ -25,15 +23,9 @@ class PHPZabbix implements RequestCallbackInterface
 
     public function __construct(ClientInterface $client, $apiUrl)
     {
-        $this->client = $client;
+        $this->client = new \GuzzleHttp\Client();
         $this->apiUrl = $apiUrl;
     }
-
-    public static function withDefaultClient($apiUrl) {
-        $client = new \GuzzleHttp\Client();
-        return new PHPZabbix($client, $apiUrl);
-    }
-
 
     public function call($method, array $params = [])
     {


### PR DESCRIPTION
The description usage of this lib is not working as intended, with the error:

"Type error: Argument 1 passed to phpzabbix\PHPZabbix::__construct() must be an instance of GuzzleHttp\ClientInterface, string given, called in /var/www/app/Http/Controllers/ZabbixController.php on line 21"

If the change was not necessary, I like to ask how to proceed to work with the original code.

Regards,

Isaque Profeta dos Reis